### PR TITLE
Automatic IPv6 detection while converting long to IP

### DIFF
--- a/src/Ip.php
+++ b/src/Ip.php
@@ -324,10 +324,10 @@ abstract class Ip
      * @param long $dec IPv4 or IPv6 long
      * @return string If IP is valid returns IP string representation, otherwise ''.
      */
-    public static function long2ip($dec, $ipv6 = false)
+    public static function long2ip($dec)
     {
         $ipstr = '';
-        if ($ipv6) {
+        if ($dec > 4294967295) { // IPv6
             if (!function_exists('bcadd')) {
                 throw new \RuntimeException('BCMATH extension not installed!');
             }

--- a/src/Ip.php
+++ b/src/Ip.php
@@ -324,10 +324,10 @@ abstract class Ip
      * @param long $dec IPv4 or IPv6 long
      * @return string If IP is valid returns IP string representation, otherwise ''.
      */
-    public static function long2ip($dec)
+    public static function long2ip($dec, $ipv6 = true)
     {
         $ipstr = '';
-        if ($dec > 4294967295) { // IPv6
+        if ($dec > 0xFFFFFFFF && $ipv6) { // IPv6
             if (!function_exists('bcadd')) {
                 throw new \RuntimeException('BCMATH extension not installed!');
             }


### PR DESCRIPTION
Due to ip2long() function being able to handle both v4 and v6 addresses, it takes another step for the developer to save information about IP address, for it being decoded by long2ip.

Max long value coming from ipv4 -> 255.255.255.255 is 4294967295 (32bit max integer).

Smallest ipv6 address is 2000:: -> 42535295865117307932921825928971026432.

So it is safe to use this condition.

Additionally odd behaviour is about ::1 returning 1, while 127.0.0.1 is 2130706433.
:: returns 0.